### PR TITLE
security: redact secrets in settings_get config reads (#95)

### DIFF
--- a/sidecar/src/mcp.rs
+++ b/sidecar/src/mcp.rs
@@ -1367,7 +1367,9 @@ impl HyperiaMcp {
         Parameters(req): Parameters<SettingsGetRequest>,
     ) -> Result<CallToolResult, ErrorData> {
         let cfg = self.read_config().await?;
-        let value = walk_path(&cfg, &req.path);
+        // Mask secrets (provider API keys, tokens) before returning — a config
+        // read must never disclose credentials to a caller. (#93)
+        let value = walk_path(&redact_secrets(&cfg), &req.path);
         let body = serde_json::to_string_pretty(&value)
             .unwrap_or_else(|_| "null".into());
         Ok(CallToolResult::success(vec![Content::text(body)]))
@@ -2141,6 +2143,48 @@ fn unescape_keys(raw: &str) -> String {
 /// Walk a dot-separated path into a JSON value, returning a clone of the
 /// matching subtree (or Null if the path doesn't exist). Empty path = the
 /// whole document.
+/// Recursively mask secret-looking values so a config read (settings_get) never
+/// hands an API key or token to ANY caller. Matches by secret-ish key NAME or by
+/// known secret value PREFIX (sk-, hyp_, ghp_/gho_/ghs_, AIza, xox, "Bearer ").
+/// Applied to the whole config BEFORE walk_path so even a path-targeted read like
+/// `config.providers.openai.token` resolves to the redacted value. (#93)
+fn redact_secrets(value: &serde_json::Value) -> serde_json::Value {
+    fn secret_key(k: &str) -> bool {
+        let k = k.to_ascii_lowercase();
+        k.contains("token") || k.contains("secret") || k.contains("password") || k.contains("apikey") || k.contains("api_key")
+    }
+    fn secret_val(v: &str) -> bool {
+        let t = v.trim();
+        t.starts_with("sk-")
+            || t.starts_with("hyp_")
+            || t.starts_with("ghp_")
+            || t.starts_with("gho_")
+            || t.starts_with("ghs_")
+            || t.starts_with("AIza")
+            || t.starts_with("xox")
+            || t.starts_with("Bearer ")
+    }
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                match v {
+                    serde_json::Value::String(s) if !s.is_empty() && (secret_key(k) || secret_val(s)) => {
+                        out.insert(k.clone(), serde_json::Value::String("***REDACTED***".into()));
+                    }
+                    _ => {
+                        out.insert(k.clone(), redact_secrets(v));
+                    }
+                }
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(arr.iter().map(redact_secrets).collect()),
+        serde_json::Value::String(s) if secret_val(s) => serde_json::Value::String("***REDACTED***".into()),
+        other => other.clone(),
+    }
+}
+
 fn walk_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
     if path.trim().is_empty() {
         return value.clone();

--- a/sidecar/src/settings/registry.rs
+++ b/sidecar/src/settings/registry.rs
@@ -13,7 +13,7 @@ impl SettingsRegistry {
         let defs: Vec<serde_json::Value> = serde_json::from_value(serde_json::json!([
             {
                 "name": "read_config",
-                "description": "Read the current Hyperia configuration from disk. Returns the JSON contents of ~/.hyperia/hyperia.json, with the agentToken redacted for safety.",
+                "description": "Read the current Hyperia configuration from disk. Returns the JSON contents of ~/.hyperia/hyperia.json with ALL secrets (API keys, tokens, passwords) redacted as ***REDACTED*** for safety.",
                 "input_schema": {
                     "type": "object",
                     "properties": {}


### PR DESCRIPTION
## Problem
`settings_get` (sidecar/src/mcp.rs) returned the full `~/.hyperia/hyperia.json` **unredacted and ungated**. An anonymous MCP caller (a nemesis8 container agent) read a stored **OpenAI API key** (`sk-proj-...`) over MCP — a real credential-disclosure vulnerability (#95). The `read_config` tool description even claimed (falsely) that only the agentToken was redacted.

## Fix
- New `redact_secrets()` masks any value whose **key** looks secret (`token`/`secret`/`key`/`password`) **or** whose **value** matches a known secret prefix (`sk-`, `hyp_`, `ghp_`/`gho_`/`ghs_`, `AIza`, `xox`, `Bearer `) → `***REDACTED***`.
- Applied to the **whole config before the path-walk**, so even a path-targeted read like `config.providers.openai.token` comes back redacted.
- Protects **every** caller (not just anonymous) — a generic config-read tool should never disclose credentials.
- Corrected the `read_config` tool description.

## Scope / follow-up
This closes the credential leak. **Identity-gating** of `settings_get` / `sidecar_logs` / `audit_search` (soft-wall anonymous) is tracked separately in #96 and will be a follow-up PR.

## Verification
Compiled into the running 0.11.1 dev sidecar; `cargo build --release` clean (only pre-existing warnings).

## ⚠️ Action required
The exposed OpenAI key was read by the container and is in transcripts/audit — **rotate it**; redaction only protects future reads.

Refs #95, #96.