### PR TITLE
security: gate sidecar_logs + audit_search behind identity (#96)

### DIFF
--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -201,9 +201,13 @@ async fn get_mcp_python() -> impl axum::response::IntoResponse {
     )
 }
 
-async fn get_logs(State(state): State<AppState>) -> Json<Vec<String>> {
+async fn get_logs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<String>>, (StatusCode, String)> {
+    enforce_identified(&state, &headers).await?;
     let lines = state.log_buffer.lock().unwrap();
-    Json(lines.iter().cloned().collect())
+    Ok(Json(lines.iter().cloned().collect()))
 }
 
 #[derive(serde::Deserialize)]
@@ -919,6 +923,23 @@ async fn enforce_create(
 
 /// Gate a named capability action (file edit / settings / web-eval / manage /
 /// …) on the caller's identity + capability grant. Mirrors enforce_create.
+/// Soft-wall anonymous callers from sensitive reads (logs, audit). Any
+/// non-anonymous identity (system/agent/pane) passes. Respects the global
+/// enforcement toggle — when enforcement is off, reads are open. (#96)
+async fn enforce_identified(state: &AppState, headers: &HeaderMap) -> Result<(), (StatusCode, String)> {
+    if !state.bridge.perms().enforced() {
+        return Ok(());
+    }
+    let id = state.bridge.resolve_caller(bearer_token(headers).as_deref()).await;
+    if id.is_anonymous() {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "This read requires identity. Send 'Authorization: Bearer <token>' — your pane token is in the HYPERIA_AGENT_TOKEN env var.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn enforce_capability(
     state: &AppState,
     headers: &HeaderMap,
@@ -1042,8 +1063,11 @@ async fn get_perm_state(State(state): State<AppState>) -> Json<serde_json::Value
 /// Search the audit log (read-only). Filters: identity, path (substrings),
 /// status, since_ms, limit.
 async fn get_audit_search(
+    State(state): State<AppState>,
+    headers: HeaderMap,
     Query(params): Query<std::collections::HashMap<String, String>>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    enforce_identified(&state, &headers).await?;
     let identity = params.get("identity").map(|s| s.as_str());
     let path_q = params.get("path").map(|s| s.as_str());
     let status = params.get("status").and_then(|s| s.parse::<u16>().ok());
@@ -1054,7 +1078,7 @@ async fn get_audit_search(
         .unwrap_or(100)
         .min(2000);
     let results = audit::search(identity, path_q, status, since, limit);
-    Json(serde_json::json!({ "count": results.len(), "results": results }))
+    Ok(Json(serde_json::json!({ "count": results.len(), "results": results })))
 }
 
 /// Mint/return the access token for a pane. The pane menu copies this and the

--- a/sidecar/src/mcp.rs
+++ b/sidecar/src/mcp.rs
@@ -1113,8 +1113,8 @@ impl HyperiaMcp {
     }
 
     #[tool(description = "Read sidecar logs.")]
-    async fn sidecar_logs(&self) -> Result<CallToolResult, ErrorData> {
-        let text = self.get("/api/logs").await?;
+    async fn sidecar_logs(&self, ctx: RequestContext<RoleServer>) -> Result<CallToolResult, ErrorData> {
+        let text = self.get_as("/api/logs", forwarded_auth(&ctx).as_deref()).await?;
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 
@@ -1122,6 +1122,7 @@ impl HyperiaMcp {
     async fn audit_search(
         &self,
         Parameters(req): Parameters<AuditSearchRequest>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         let mut q: Vec<String> = Vec::new();
         if let Some(i) = &req.identity {
@@ -1141,7 +1142,7 @@ impl HyperiaMcp {
         } else {
             format!("/api/audit/search?{}", q.join("&"))
         };
-        let resp = self.get(&path).await?;
+        let resp = self.get_as(&path, forwarded_auth(&ctx).as_deref()).await?;
         Ok(CallToolResult::success(vec![Content::text(resp)]))
     }
 
@@ -2332,6 +2333,22 @@ impl HyperiaMcp {
             .await
             .map_err(|e| ErrorData::internal_error(format!("HTTP error: {e}"), None))?;
         resp.text().await
+            .map_err(|e| ErrorData::internal_error(format!("Read error: {e}"), None))
+    }
+
+    /// GET that forwards a caller Authorization header so gated read endpoints
+    /// (enforce_identified) see the real identity instead of anonymous. (#96)
+    async fn get_as(&self, path: &str, auth: Option<&str>) -> Result<String, ErrorData> {
+        let mut rb = self.client.get(format!("{}{}", self.base_url, path));
+        if let Some(a) = auth {
+            rb = rb.header(reqwest::header::AUTHORIZATION, a);
+        }
+        let resp = rb
+            .send()
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("HTTP error: {e}"), None))?;
+        resp.text()
+            .await
             .map_err(|e| ErrorData::internal_error(format!("Read error: {e}"), None))
     }
 


### PR DESCRIPTION
## Problem
`GET /api/logs` (sidecar log buffer) and `GET /api/audit/search` (the audit log) were readable by **any** caller, including **anonymous** — leaking command output, filesystem paths, and who-did-what to an unidentified MCP caller. Part of the read-gating gap (#96, #94).

## Fix
- New `enforce_identified()` helper — soft-walls anonymous (401), allows any system/agent/pane identity, and **respects the global enforcement toggle** (reads stay open when enforcement is off).
- Applied to `get_logs` and `get_audit_search`.
- The MCP `sidecar_logs` / `audit_search` tools now **forward the caller token** (new `get_as` proxy) so identified agents pass and anonymous is rejected.

## Safety
Verified that the renderer, app, and dashboard do **not** call `/api/logs` or `/api/audit/search` — so no UI breaks. `/api/status` (orientation, polled by the renderer) is intentionally left open.

`settings_get` is separately handled by redaction in #105.

## Verification
`cargo build --release` clean; running in the local 0.11.1 dev sidecar.

Refs #96, #94. Pairs with #105.